### PR TITLE
skip using the --headers flag when no headers are specified

### DIFF
--- a/src/cpplint.js
+++ b/src/cpplint.js
@@ -24,7 +24,7 @@ class cpplint {
             "--output=eclipse",
             this.base.get_cfg(this.settings, "--counting=", "detailed", true),
             this.base.get_cfg(this.settings, "--extensions=", "hxx,h++,cxx,cc,hh,h,cpp,cuh,c,hpp,c++,cu", true),
-            this.base.get_cfg(this.settings, "--headers=", "hxx,h++,hh,h,cuh,hpp", true),
+            this.base.get_cfg(this.settings, "--headers=", "hxx,h++,hh,h,cuh,hpp", false),
             this.base.get_cfg(this.settings, "--verbose=", 0, true),
             this.base.get_cfg(this.settings, "--filter=", "", true),
             this.base.get_cfg(this.settings, "--linelength=", 120, true)
@@ -114,7 +114,7 @@ class cpplint {
         const line = document.lineAt(pos.line);
 
         let actions = [];
-        const fix = new vscode.CodeAction(`cpplint-suppress`, vscode.CodeActionKind.QuickFix);  
+        const fix = new vscode.CodeAction(`cpplint-suppress`, vscode.CodeActionKind.QuickFix);
         let suppress_str = "  // NOLINT";
         const startPos = document.lineAt(pos.line).range.end;
         const endPos = new vscode.Position(line.lineNumber, startPos.character + suppress_str.length);


### PR DESCRIPTION
Hey, first of all, thanks for working on this plugin! I have tried other lint plugins, but I like this one because its simple works great for remote sessions with containers as well. 

I am trying to use this plugin for setting up a development environment for [ROS](http://wiki.ros.org/). I am trying to use a custom `cpplint` executable which supports checking lint best practices for things specific to ROS code as well. This is the executable that is used by other tools we use for ROS development as well. https://github.com/ros/roslint/blob/0.11.2/src/roslint/cpplint.py#L62

Unfortunately, this executable does not support specifying the `--headers` flag, so when running lint through this plugin the command fails. 

I don't think this breaks any backwards compatibility and the default argument still works as expected. Let me know if the change makes sense, or if there is another simpler way to skip using the `--headers` flag. 

Thanks!