### PR TITLE
Add support for cppcheck premium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.vsix

--- a/package.json
+++ b/package.json
@@ -184,6 +184,17 @@
 					]],
 					"description": "see ReadMe"
 				},
+				"cpp-check-lint.cppcheck.--premium=": {
+					"type": "array",
+					"examples": [
+						[
+							"misra-c-2012",
+							"cert-c-2016"
+						]
+					],
+					"default": [],
+					"description": "premium"
+				},
 				"cpp-check-lint.cppcheck.--customargs=": {
 					"type": "string",
 					"default": "",

--- a/src/cppcheck.js
+++ b/src/cppcheck.js
@@ -127,6 +127,17 @@ class cppcheck {
             }
         }
 
+        let premium = this.base.get_cfg(this.settings, "--premium=", false, []);
+        if (0 != premium.length) {
+            for (let value of premium) {
+                if ("string" == typeof (value)) {
+                    if (!common.is_empty_str(value)) {
+                        res.push("--premium=" + value);
+                    }
+                }
+            }
+        }
+
         common.remove_empty(res);
         return res;
     }
@@ -308,7 +319,7 @@ class cppcheck {
             });
         }
     }
- 
+
     /**
      * @param {string} result
      */
@@ -318,7 +329,7 @@ class cppcheck {
             vscode.window.setStatusBarMessage(" " + result, 2000);
         }
      }
-    
+
 
     /**
      * @param {boolean} isFile


### PR DESCRIPTION
The Cppcheck premium version uses the argument ` --premium` for additional check like MisraC instead of `--addon`.

https://files.cppchecksolutions.com/manual.pdf

```shell
cppcheck --premium=misra-c-2012 ....
```