### PR TITLE
change cppcheck and cpplint customargs to array types

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,9 +196,15 @@
 					"description": "premium"
 				},
 				"cpp-check-lint.cppcheck.--customargs=": {
-					"type": "string",
-					"default": "",
-					"description": "customargs"
+					"type": "array",
+					"default": [],
+					"description": "customargs",
+					"examples": [
+						[
+							"--library=<cfg>",
+							"--check-level=<level>"
+						]
+					]
 				},
 				"cpp-check-lint.cppcheck.--enable": {
 					"type": "boolean",
@@ -369,8 +375,8 @@
 					"description": "Enable or disable the cpplint"
 				},
 				"cpp-check-lint.cpplint.--customargs=": {
-					"type": "string",
-					"default": "",
+					"type": "array",
+					"default": [],
 					"description": "customargs"
 				},
 				"cpp-check-lint.cpplint.--executable": {

--- a/src/cppcheck.js
+++ b/src/cppcheck.js
@@ -43,10 +43,17 @@ class cppcheck {
             this.base.get_cfg(this.settings, "--std_c++=", true, null, "--std="),
             this.base.get_cfg(this.settings, "--inline-suppr", true),
             this.base.get_cfg(this.settings, "--suppressions-list=", true),
-            this.base.get_cfg(this.settings, "--report-progress", true),
-            this.base.get_cfg(this.settings, "--customargs=", false),
-
+            this.base.get_cfg(this.settings, "--report-progress", true)
         );
+
+        let custom = this.base.get_cfg(this.settings, "--customargs=", false, []);
+        if (0 != custom.length) {
+            for (let value of custom) {
+                if (!common.is_empty_str(value)) {
+                    res.push(value)
+                }
+            }
+        }
 
         let exclude = this.base.get_cfg(this.settings, "-i ", false, []);
         if (0 != exclude.length) {

--- a/src/cpplint.js
+++ b/src/cpplint.js
@@ -38,10 +38,18 @@ class cpplint {
             this.base.get_cfg(this.settings, "--headers=", true),
             this.base.get_cfg(this.settings, "--verbose=", true),
             this.base.get_cfg(this.settings, "--filter=", true),
-            this.base.get_cfg(this.settings, "--linelength=", true),
-            this.base.get_cfg(this.settings, "--customargs=", false)
+            this.base.get_cfg(this.settings, "--linelength=", true)
         );
 
+        let custom = this.base.get_cfg(this.settings, "--customargs=", false, []);
+        if (0 != custom.length) {
+            for (let value of custom) {
+                if (!common.is_empty_str(value)) {
+                    res.push(value)
+                }
+            }
+        }
+        
         let exclude = this.base.get_cfg(this.settings, "--exclude=", false, []);
         if (0 != exclude.length) {
             for (let value of exclude) {


### PR DESCRIPTION
This pull request updates the `cppcheck` and `cpplint` configurations to use array types for the `--customargs` options. 